### PR TITLE
Attempt to fix error of null imdbID

### DIFF
--- a/Sources/MovieDB/Media/Movies/DetailedMovie.swift
+++ b/Sources/MovieDB/Media/Movies/DetailedMovie.swift
@@ -26,7 +26,7 @@ class DetailedMovie: BasicMovie {
     let budget: Int?
     let genres: [Genre]
     let homepage: URL?
-    let imdbID: String
+    let imdbID: String?
     let productionCompanies: [ProductionCompany]
     let productionCountries: [ProductionCountry]
     let revenue: Int?
@@ -41,7 +41,7 @@ class DetailedMovie: BasicMovie {
         genres = try container.decode([Genre].self, forKey: .genres)
         let homepageString = try container.decodeIfPresent(String.self, forKey: .homepage)
         homepage = homepageString.flatMap(URL.init(string:))
-        imdbID = try container.decode(String.self, forKey: .imdbID)
+        imdbID = try container.decodeIfPresent(String.self, forKey: .imdbID)
         productionCompanies = try container.decode([ProductionCompany].self, forKey: .productionCompanies)
         productionCountries = try container.decode([ProductionCountry].self, forKey: .productionCountries)
         revenue = try container.decodeIfPresent(Int.self, forKey: .revenue)


### PR DESCRIPTION
I discovered that at some movies, the imdbID is not available. The GraphQL wrapper instead of returning null, throws an error and fails to fetch the whole node - as it is a mandatory field.
With this change, I made it an optional field.